### PR TITLE
Allow to be pushed to ruby-gems + Update Gem Authors

### DIFF
--- a/atrium-ruby.gemspec
+++ b/atrium-ruby.gemspec
@@ -6,8 +6,8 @@ require 'atrium/version'
 Gem::Specification.new do |spec|
   spec.name          = "atrium-ruby"
   spec.version       = ::Atrium::VERSION
-  spec.authors       = ["Jon Carstens"]
-  spec.email         = ["jon.carstens@mx.com"]
+  spec.authors       = ["Jon Carstens, Dan Jones, Zach Toolson"]
+  spec.email         = ["jon.carstens@mx.com, dan.jones@mx.com, zach.toolson@mx.com"]
 
   spec.summary       = "Ruby wrapper for the Atrium API by MX"
   spec.description   = "Ruby wrapper for the Atrium API by MX"

--- a/atrium-ruby.gemspec
+++ b/atrium-ruby.gemspec
@@ -12,14 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Ruby wrapper for the Atrium API by MX"
   spec.description   = "Ruby wrapper for the Atrium API by MX"
   spec.homepage      = "http://github.com/mxenabled/atrium-ruby"
-
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
-  end
+  spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"


### PR DESCRIPTION
## Currently, you cannot release the gem.

### This allows the gem to be released to ruby-gems via bundler by moving the lines that prevent that from happening. 

@ztoolson 