### PR TITLE
Allow base_url for requsts to be configurable

### DIFF
--- a/lib/atrium.rb
+++ b/lib/atrium.rb
@@ -14,13 +14,13 @@ require "atrium/user"
 require "atrium/version"
 
 module Atrium
-  BASE_URL = "https://vestibule.mx.com".freeze
   ##
   # mx-api-key and mx-client-id are required for Atrium
   #
   # Atrium.configure do |config|
   #   config.mx_api_key = generated_api_key
   #   config.mx_client_id = generated_client_id
+  #   config.base_url = "https://atrium.mx.com" # for production URL. this will default to vestibule
   # end
   #
   class << self

--- a/lib/atrium/client.rb
+++ b/lib/atrium/client.rb
@@ -1,15 +1,16 @@
 module Atrium
   class Client
-    attr_accessor :mx_api_key, :mx_client_id
+    attr_accessor :mx_api_key, :mx_client_id, :base_url
 
-    def initialize(api_key = nil, client_id = nil)
+    def initialize(api_key = nil, client_id = nil, base_url = "https://vestibule.mx.com")
       @mx_api_key = api_key
       @mx_client_id = client_id
+      @base_url = base_url
     end
 
     def make_request(method, endpoint, body = {}, headers = {})
       headers = default_headers.merge(headers)
-      url = "#{::Atrium::BASE_URL}/#{endpoint}"
+      url = "#{self.base_url}/#{endpoint}"
       response = http_client.public_send(method, url, ::JSON.dump(body), headers)
 
       handle_response(response)

--- a/lib/atrium/client.rb
+++ b/lib/atrium/client.rb
@@ -10,7 +10,8 @@ module Atrium
 
     def make_request(method, endpoint, body = {}, headers = {})
       headers = default_headers.merge(headers)
-      url = "#{self.base_url}/#{endpoint}"
+      url = "#{self.base_url}#{endpoint}"
+
       response = http_client.public_send(method, url, ::JSON.dump(body), headers)
 
       handle_response(response)


### PR DESCRIPTION
By default the url will use "https://vestibule.mx.com", but can be configured to any url. This will allow the gem to be used with "https://atrium.mx.com".

//RFC @film42 @jjcarstens @vintagepenguin 