### PR TITLE
Fix Member#accounts endpoint typo.

### DIFF
--- a/lib/atrium/member.rb
+++ b/lib/atrium/member.rb
@@ -46,7 +46,7 @@ module Atrium
     # INSTANCE METHODS
     #
     def accounts
-      endpoint = "users/#{self.user_guid}/members/#{self.guid}/account"
+      endpoint = "users/#{self.user_guid}/members/#{self.guid}/accounts"
       accounts_response = ::Atrium.client.make_request(:get, endpoint)
 
       accounts_response["accounts"].map do |account|

--- a/lib/atrium/member.rb
+++ b/lib/atrium/member.rb
@@ -118,7 +118,7 @@ module Atrium
 
     def transactions
       endpoint = "users/#{self.user_guid}/members/#{self.guid}/transactions"
-      transactions_response = ::Atrium.client.make_request(:post, endpoint)
+      transactions_response = ::Atrium.client.make_request(:get, endpoint)
 
       transactions_response["transactions"].map do |transaction|
         ::Atrium::Transaction.new(transaction)


### PR DESCRIPTION
The URL for account members is `/users/:user_guid/members/:member_guid/accounts`

//RFC @film42 @jjcarstens @vintagepenguin 