### PR TITLE
Fix for Paginate#endpoint_name method to prepend '/' in front of the …

### DIFF
--- a/lib/atrium/paginate.rb
+++ b/lib/atrium/paginate.rb
@@ -9,9 +9,9 @@ module Atrium
 
     def endpoint_name(query_params: nil)
       @endpoint = if query_params.present?
-         klass_name + "?" + URI.encode_www_form(query_params) + "&"
+        "/" + klass_name + "?" + URI.encode_www_form(query_params) + "&"
       else
-        klass_name + "?"
+        "/" + klass_name + "?"
       end
     end
 


### PR DESCRIPTION
…endpoint name since it is not done in the Client module

This fixes the `Institution#list` method as it was failing because the url was not being created properly when joining the base_url and the endpoint_name (missing a '/')