### PR TITLE
Limit the institutions returned when using the limit option

### DIFF
--- a/lib/atrium/member.rb
+++ b/lib/atrium/member.rb
@@ -78,9 +78,9 @@ module Atrium
       member_response = ::Atrium.client.make_request(:get, endpoint)
 
       member_params = member_response["challenges"]
-      challenges = member_params.map do |ch|
-        ch[:member_guid] = self.guid
-        ::Atrium::Challenge.new(ch)
+      challenges = member_params.map do |challenge|
+        challenge[:member_guid] = self.guid
+        ::Atrium::Challenge.new(challenge)
       end
       challenges
     end

--- a/lib/atrium/paginate.rb
+++ b/lib/atrium/paginate.rb
@@ -62,7 +62,12 @@ module Atrium
         end
         @current_page += 1
       end
-      list
+
+      if limit.present?
+        list.first(limit)
+      else
+        list
+      end
     end
 
     def response_list_in_batches(limit: nil, &block)


### PR DESCRIPTION
Fixes #18 

Current behavior with this fix:

```
irb(main):002:0> ::Atrium::Institution.list(query_params: { name: 'chase' }, limit: 4).size
=> 1
irb(main):003:0> ::Atrium::Institution.list(query_params: { name: 'c' }, limit: 4).size
=> 4
irb(main):004:0> ::Atrium::Institution.list(limit: 4).size
=> 4
irb(main):005:0> ::Atrium::Institution.list(limit: 5).size
=> 5
```

//RFC @jjcarstens @film42 