### PR TITLE
Setup travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+rvm:
+ - 2.4
+ - 2.3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Atrium-Ruby
+# Atrium-Ruby [![Build Status](https://travis-ci.org/mxenabled/atrium-ruby.svg?branch=master)](https://travis-ci.org/mxenabled/atrium-ruby)
 
 A Ruby wrapper for use with the [MX Atrium API](https://atrium.mx.com). In order to make requests, you will need to [sign up for MX Atrium API](https://atrium.mx.com/developers/sign_up) and get a `MX-API-KEY` and `MX-CLIENT-ID`. Then, configure your instance with:
 ```ruby

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,5 @@
-require "bundler/gem_tasks"
-task :default => :spec
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+task default: :spec


### PR DESCRIPTION
This adds Travis-ci to the project. All that is missing is for a collaborator to enable it on https://travis-ci.org . Completes #27 

The currently running version of this may be observed at https://travis-ci.org/AquilaLoans/atrium-ruby