### PR TITLE
Add new pagination mixin - implement for transactions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,5 +6,7 @@ AllCops:
   Include:
     - 'Gemfile'
     - 'Rakefile'
+Style/FileName:
+  Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false

--- a/lib/atrium.rb
+++ b/lib/atrium.rb
@@ -1,6 +1,7 @@
 require "active_attr"
 require "httpclient"
 require "json"
+require "atrium/pageable"
 require "atrium/paginate"
 
 require "atrium/account"

--- a/lib/atrium/pageable.rb
+++ b/lib/atrium/pageable.rb
@@ -6,13 +6,8 @@ module Atrium
   module Pageable
     DEFAULT_RECORDS_PER_PAGE = 25
 
-    def pagination_info(endpoint, query_params)
-      response = make_get_request(endpoint, query_params.merge(:page => 1))
-      response["pagination"]
-    end
-
     def make_get_request(endpoint, query_params)
-      uri = endpoint + "?" + ::URI.encode_www_form(query_params)
+      uri = endpoint + "?" + ::URI.encode_www_form(query_params.sort)
       ::Atrium.client.make_request(:get, uri)
     end
 
@@ -34,6 +29,8 @@ module Atrium
     end
 
     def paginate_in_batches(options = {})
+      fail ::ArgumentError, "A block is required" unless block_given?
+
       endpoint = options.fetch(:endpoint)
       resource = options.fetch(:resource)
 
@@ -66,6 +63,11 @@ module Atrium
       end
 
       nil
+    end
+
+    def pagination_info(endpoint, query_params)
+      response = make_get_request(endpoint, query_params.merge(:page => 1))
+      response["pagination"]
     end
   end
 end

--- a/lib/atrium/pageable.rb
+++ b/lib/atrium/pageable.rb
@@ -1,0 +1,62 @@
+module Atrium
+  class PaginationBatch < ::Array
+    attr_accessor :total_pages, :total_entries, :current_page, :records_per_page
+  end
+
+  module Pageable
+    DEFAULT_RECORDS_PER_PAGE = 25
+
+    def pagination_info(endpoint, query_params)
+      response = make_get_request(endpoint, query_params.merge(:page => 1))
+      response["pagination"]
+    end
+
+    def make_get_request(endpoint, query_params)
+      uri = endpoint + "?" + ::URI.encode_www_form(query_params)
+      ::Atrium.client.make_request(:get, uri)
+    end
+
+    def paginate_each(options = {})
+      paginate_in_batches(options) do |batch|
+        batch.each do |record|
+          yield record
+        end
+      end
+    end
+
+    def paginate_in_batches(options = {})
+      endpoint = options.fetch(:endpoint)
+      resource = options.fetch(:resource)
+
+      query_params = options.fetch(:query_params, {})
+      limit = options.fetch(:limit, nil)
+      current_page = options.fetch(:initial_page, 1)
+      records_per_page = options.fetch(:records_per_page, DEFAULT_RECORDS_PER_PAGE)
+
+      pagination_info_query_params = query_params.merge(:records_per_page => records_per_page)
+      pagination = pagination_info(endpoint, pagination_info_query_params)
+      total_pages = pagination["total_pages"]
+      total_entries = pagination["total_entries"]
+      # "total_pages > 1" check exists since some query_params only return 1 page
+      total_pages = limit / records_per_page if limit.present? && total_pages > 1
+
+      until current_page > total_pages
+        params = query_params.merge(:page => current_page, :records_per_page => records_per_page)
+        response = make_get_request(endpoint, params)
+
+        records = response[resource].map { |attributes| new(attributes) }
+
+        batch = ::Atrium::PaginationBatch.new(records)
+        batch.total_pages = total_pages
+        batch.total_entries = total_entries
+        batch.current_page = current_page
+        batch.records_per_page = records_per_page
+        yield batch
+
+        current_page += 1
+      end
+
+      nil
+    end
+  end
+end

--- a/lib/atrium/pageable.rb
+++ b/lib/atrium/pageable.rb
@@ -16,6 +16,15 @@ module Atrium
       ::Atrium.client.make_request(:get, uri)
     end
 
+    def paginate(options = {})
+      records_per_page = options.fetch(:records_per_page, DEFAULT_RECORDS_PER_PAGE)
+      results = PaginationBatch.new
+      paginate_in_batches(options.merge(:limit => records_per_page)) do |batch|
+        results = batch
+      end
+      results
+    end
+
     def paginate_each(options = {})
       paginate_in_batches(options) do |batch|
         batch.each do |record|

--- a/lib/atrium/transaction.rb
+++ b/lib/atrium/transaction.rb
@@ -42,6 +42,13 @@ module Atrium
       end
     end
 
+    def self.list_each(options = {})
+      user_guid = options.fetch(:user_guid)
+      endpoint = "/users/#{user_guid}/transactions"
+      options = options.merge(:endpoint => endpoint, :resource => "transactions")
+      paginate_each(options) { |batch| yield batch }
+    end
+
     def self.list_in_batches(options = {})
       user_guid = options.fetch(:user_guid)
       endpoint = "/users/#{user_guid}/transactions"

--- a/lib/atrium/transaction.rb
+++ b/lib/atrium/transaction.rb
@@ -1,5 +1,3 @@
-require "atrium/pageable"
-
 module Atrium
   class Transaction
     extend ::Atrium::Pageable

--- a/lib/atrium/transaction.rb
+++ b/lib/atrium/transaction.rb
@@ -35,8 +35,7 @@ module Atrium
     attribute :user_guid
 
     def self.list(user_guid:)
-      raw_transactions = ::Atrium.client.make_request(:get, base_endpoint(user_guid))
-
+      raw_transactions = ::Atrium.client.make_request(:get, "/users/#{user_guid}/transactions")
       raw_transactions["transactions"].map do |raw_transaction|
         ::Atrium::Transaction.new(raw_transaction)
       end
@@ -57,14 +56,10 @@ module Atrium
     end
 
     def self.read(user_guid:, transaction_guid:)
-      endpoint = ::URI.join(base_endpoint(user_guid), "#{transaction_guid}")
+      endpoint = "/users/#{user_guid}/transactions/#{transaction_guid}"
       raw_transaction = ::Atrium.client.make_request(:get, endpoint)
 
       ::Atrium::Transaction.new(raw_transaction["transaction"])
-    end
-
-    def self.base_endpoint(user_guid:)
-      "/users/#{user_guid}/transactions"
     end
   end
 end

--- a/lib/atrium/transaction.rb
+++ b/lib/atrium/transaction.rb
@@ -34,32 +34,31 @@ module Atrium
     attribute :updated_at
     attribute :user_guid
 
-    def self.list(user_guid:)
-      raw_transactions = ::Atrium.client.make_request(:get, "/users/#{user_guid}/transactions")
-      raw_transactions["transactions"].map do |raw_transaction|
-        ::Atrium::Transaction.new(raw_transaction)
-      end
+    def self.list(options = {})
+      options = _transaction_pagination_options(options)
+      paginate(options)
     end
 
     def self.list_each(options = {})
-      user_guid = options.fetch(:user_guid)
-      endpoint = "/users/#{user_guid}/transactions"
-      options = options.merge(:endpoint => endpoint, :resource => "transactions")
-      paginate_each(options) { |batch| yield batch }
+      options = _transaction_pagination_options(options)
+      paginate_each(options) { |transaction| yield transaction }
     end
 
     def self.list_in_batches(options = {})
-      user_guid = options.fetch(:user_guid)
-      endpoint = "/users/#{user_guid}/transactions"
-      options = options.merge(:endpoint => endpoint, :resource => "transactions")
+      options = _transaction_pagination_options(options)
       paginate_in_batches(options) { |batch| yield batch }
     end
 
     def self.read(user_guid:, transaction_guid:)
       endpoint = "/users/#{user_guid}/transactions/#{transaction_guid}"
       raw_transaction = ::Atrium.client.make_request(:get, endpoint)
-
       ::Atrium::Transaction.new(raw_transaction["transaction"])
+    end
+
+    def self._transaction_pagination_options(options)
+      user_guid = options.fetch(:user_guid)
+      endpoint = "/users/#{user_guid}/transactions"
+      options.merge(:endpoint => endpoint, :resource => "transactions")
     end
   end
 end

--- a/spec/lib/atrium/pageable_spec.rb
+++ b/spec/lib/atrium/pageable_spec.rb
@@ -1,0 +1,163 @@
+require "spec_helper"
+
+RSpec.describe ::Atrium::Pageable do
+  include_context "configure"
+
+  class ExampleClass
+    extend ::Atrium::Pageable
+    include ::ActiveAttr::Model
+    attribute :code
+    attribute :name
+    attribute :url
+  end
+
+  subject { ExampleClass }
+
+  let(:first_institution) { ExampleClass.new({ "code" => "batman", "name" => "Batman Bank", "url" => "https://batman.com/" }) }
+  let(:first_page_response) do
+    {
+      "institutions" => [
+        { "code" => "batman", "name" => "Batman Bank", "url" => "https://batman.com/" },
+        { "code" => "batman", "name" => "Batman CC", "url" => "None" },
+      ],
+      "pagination" => {
+        "current_page" => 1, "per_page" => 25, "total_entries" => 50, "total_pages" => total_pages
+      }
+    }
+  end
+  let(:second_page_response) do
+    {
+      "institutions" => [
+        { "code" => "batman", "name" => "Batman WBC", "url" => "https://www.batman.com" }
+      ],
+      "pagination" => {
+        "current_page" => 2, "per_page" => 25, "total_entries" => 50, "total_pages" => total_pages
+      }
+    }
+  end
+  let(:total_pages) { 2 }
+
+  before do
+    allow(::Atrium.client).to receive(:make_request).with(:get, "/institutions?page=1&records_per_page=25").
+                                and_return(first_page_response)
+    allow(::Atrium.client).to receive(:make_request).with(:get, "/institutions?page=2&records_per_page=25").
+                                and_return(second_page_response)
+  end
+
+  describe ".paginate" do
+    it "makes a single request using the default limit" do
+      expect(::Atrium.client).to receive(:make_request).with(:get, "/paginate_once?page=1&records_per_page=25").
+                                   and_return(first_page_response).exactly(:twice)
+      options = {
+        :endpoint => "/paginate_once",
+        :resource => "institutions"
+      }
+      batch_options = options.merge(:limit => 25)
+      expect(subject).to receive(:paginate_in_batches).with(batch_options).and_call_original
+      expect(subject.paginate(options).total_pages).to eq(1)
+    end
+
+    it "makes a single request using a custom limit" do
+      expect(::Atrium.client).to receive(:make_request).with(:get, "/paginate_once?page=1&records_per_page=100").
+                                   and_return(first_page_response).exactly(:twice)
+      options = {
+        :endpoint => "/paginate_once",
+        :resource => "institutions",
+        :records_per_page => 100,
+      }
+      batch_options = options.merge(:limit => 100)
+      expect(subject).to receive(:paginate_in_batches).with(batch_options).and_call_original
+      expect(subject.paginate(options).total_pages).to eq(1)
+    end
+
+    context "no results" do
+      let(:empty_response) do
+        {
+          "institutions" => [],
+          "pagination" => {"current_page" => 1, "per_page" => 25, "total_entries" => 0, "total_pages" => 1}
+        }
+      end
+
+      it "returns an empty pagination batch" do
+        expect(::Atrium.client).to receive(:make_request).with(:get, "/paginate_once?page=1&records_per_page=25").
+                                     and_return(empty_response).exactly(:twice)
+        options = {
+          :endpoint => "/paginate_once",
+          :resource => "institutions"
+        }
+        batch = subject.paginate(options)
+        expect(batch).to eq(::Atrium::PaginationBatch.new)
+      end
+    end
+  end
+
+  describe ".paginate_each" do
+    it "yields every transaction in each batch" do
+      records_yielded = 0
+      options = {
+        :endpoint => "/institutions",
+        :resource => "institutions"
+      }
+      subject.paginate_each(options) { records_yielded += 1 }
+      expect(records_yielded).to eq(3)
+    end
+  end
+
+  describe ".paginate_in_batches" do
+    it "fails unless a block is given" do
+      expect { subject.paginate_in_batches }.to raise_error(::ArgumentError)
+    end
+
+    context "single page response" do
+      let(:total_pages) { 1 }
+
+      it "yields a pagination batch" do
+        batch = nil
+        options = {
+          :endpoint => "/institutions",
+          :resource => "institutions"
+        }
+        subject.paginate_in_batches(options) { |b| batch = b }
+        expect(batch.size).to eq(2)
+        expect(batch.total_pages).to eq(1)
+        expect(batch.total_entries).to eq(50)
+        expect(batch.current_page).to eq(1)
+        expect(batch.first).to eq(first_institution)
+      end
+    end
+
+    context "multiple pages" do
+      it "yields two pagination batches" do
+        batches = []
+        options = {
+          :endpoint => "/institutions",
+          :resource => "institutions"
+        }
+        subject.paginate_in_batches(options) { |b| batches << b }
+        expect(batches.size).to eq(2)
+        expect(batches.first.size).to eq(2)
+        expect(batches.first.current_page).to eq(1)
+        expect(batches.last.current_page).to eq(2)
+        expect(batches.last.size).to eq(1)
+      end
+    end
+
+    context "custom query params" do
+      let(:query_params) { {:from_date => ::Date.new(2017, 10, 22)} }
+      let(:total_pages) { 1 }
+
+      it "uses the query params" do
+        expect(::Atrium.client).to receive(:make_request).with(:get, "/weird_endpoint?from_date=2017-10-22&page=1&records_per_page=25").
+                                     and_return(first_page_response).exactly(:twice)
+
+        options = {
+          :endpoint => "/weird_endpoint",
+          :resource => "institutions",
+          :query_params => query_params
+        }
+
+        subject.paginate_in_batches(options) { }
+      end
+    end
+  end
+end

--- a/spec/lib/atrium/pageable_spec.rb
+++ b/spec/lib/atrium/pageable_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ::Atrium::Pageable do
 
   subject { ExampleClass }
 
-  let(:first_institution) { ExampleClass.new({ "code" => "batman", "name" => "Batman Bank", "url" => "https://batman.com/" }) }
+  let(:first_institution) { ExampleClass.new("code" => "batman", "name" => "Batman Bank", "url" => "https://batman.com/") }
   let(:first_page_response) do
     {
       "institutions" => [
@@ -38,16 +38,16 @@ RSpec.describe ::Atrium::Pageable do
   let(:total_pages) { 2 }
 
   before do
-    allow(::Atrium.client).to receive(:make_request).with(:get, "/institutions?page=1&records_per_page=25").
-                                and_return(first_page_response)
-    allow(::Atrium.client).to receive(:make_request).with(:get, "/institutions?page=2&records_per_page=25").
-                                and_return(second_page_response)
+    allow(::Atrium.client).to receive(:make_request).with(:get, "/institutions?page=1&records_per_page=25")
+                                                    .and_return(first_page_response)
+    allow(::Atrium.client).to receive(:make_request).with(:get, "/institutions?page=2&records_per_page=25")
+                                                    .and_return(second_page_response)
   end
 
   describe ".paginate" do
     it "makes a single request using the default limit" do
-      expect(::Atrium.client).to receive(:make_request).with(:get, "/paginate_once?page=1&records_per_page=25").
-                                   and_return(first_page_response).exactly(:twice)
+      expect(::Atrium.client).to receive(:make_request).with(:get, "/paginate_once?page=1&records_per_page=25")
+        .and_return(first_page_response).exactly(:twice)
       options = {
         :endpoint => "/paginate_once",
         :resource => "institutions"
@@ -58,8 +58,8 @@ RSpec.describe ::Atrium::Pageable do
     end
 
     it "makes a single request using a custom limit" do
-      expect(::Atrium.client).to receive(:make_request).with(:get, "/paginate_once?page=1&records_per_page=100").
-                                   and_return(first_page_response).exactly(:twice)
+      expect(::Atrium.client).to receive(:make_request).with(:get, "/paginate_once?page=1&records_per_page=100")
+        .and_return(first_page_response).exactly(:twice)
       options = {
         :endpoint => "/paginate_once",
         :resource => "institutions",
@@ -74,13 +74,13 @@ RSpec.describe ::Atrium::Pageable do
       let(:empty_response) do
         {
           "institutions" => [],
-          "pagination" => {"current_page" => 1, "per_page" => 25, "total_entries" => 0, "total_pages" => 1}
+          "pagination" => { "current_page" => 1, "per_page" => 25, "total_entries" => 0, "total_pages" => 1 }
         }
       end
 
       it "returns an empty pagination batch" do
-        expect(::Atrium.client).to receive(:make_request).with(:get, "/paginate_once?page=1&records_per_page=25").
-                                     and_return(empty_response).exactly(:twice)
+        expect(::Atrium.client).to receive(:make_request).with(:get, "/paginate_once?page=1&records_per_page=25")
+          .and_return(empty_response).exactly(:twice)
         options = {
           :endpoint => "/paginate_once",
           :resource => "institutions"
@@ -143,12 +143,12 @@ RSpec.describe ::Atrium::Pageable do
     end
 
     context "custom query params" do
-      let(:query_params) { {:from_date => ::Date.new(2017, 10, 22)} }
+      let(:query_params) { { :from_date => ::Date.new(2017, 10, 22) } }
       let(:total_pages) { 1 }
 
       it "uses the query params" do
-        expect(::Atrium.client).to receive(:make_request).with(:get, "/weird_endpoint?from_date=2017-10-22&page=1&records_per_page=25").
-                                     and_return(first_page_response).exactly(:twice)
+        expect(::Atrium.client).to receive(:make_request).with(:get, "/weird_endpoint?from_date=2017-10-22&page=1&records_per_page=25")
+          .and_return(first_page_response).exactly(:twice)
 
         options = {
           :endpoint => "/weird_endpoint",
@@ -156,7 +156,7 @@ RSpec.describe ::Atrium::Pageable do
           :query_params => query_params
         }
 
-        subject.paginate_in_batches(options) { }
+        subject.paginate_in_batches(options) {}
       end
     end
   end

--- a/spec/lib/atrium/transaction_spec.rb
+++ b/spec/lib/atrium/transaction_spec.rb
@@ -127,4 +127,15 @@ RSpec.describe ::Atrium::Transaction do
       expect(response.user_guid).to eq(raw_transaction_attributes[:user_guid])
     end
   end
+
+  describe "._transaction_pagination_options" do
+    it "errors when no user_guid is provided" do
+      expect { described_class._transaction_pagination_options({}).to raise_error }
+    end
+
+    it "builds default pagination params for transactions" do
+      options = described_class._transaction_pagination_options(:user_guid => "USR-123")
+      expect(options).to eq({:endpoint => "/users/USR-123/transactions", :resource => "transactions", :user_guid => "USR-123"})
+    end
+  end
 end

--- a/spec/lib/atrium/transaction_spec.rb
+++ b/spec/lib/atrium/transaction_spec.rb
@@ -41,8 +41,10 @@ RSpec.describe ::Atrium::Transaction do
     { :transaction => raw_transaction_attributes }.to_json
   end
   let(:raw_transactions_response) do
-    { :transactions => [raw_transaction_attributes, raw_transaction_attributes] }.to_json
+    { :transactions => [raw_transaction_attributes, raw_transaction_attributes],
+      :pagination => raw_pagination_attributes }.to_json
   end
+  let(:raw_pagination_attributes) { { :total_pages => 100, :total_entries => 2500 } }
   let(:transaction_guid) { "TRN-265abee9-889b-af6a-c69b-25157db2bdd9" }
   let(:user_guid) { "USR-fa7537f3-48aa-a683-a02a-b18940482f54" }
 

--- a/spec/lib/atrium/transaction_spec.rb
+++ b/spec/lib/atrium/transaction_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe ::Atrium::Transaction do
 
     it "builds default pagination params for transactions" do
       options = described_class._transaction_pagination_options(:user_guid => "USR-123")
-      expect(options).to eq({:endpoint => "/users/USR-123/transactions", :resource => "transactions", :user_guid => "USR-123"})
+      expect(options).to eq(:endpoint => "/users/USR-123/transactions", :resource => "transactions", :user_guid => "USR-123")
     end
   end
 end


### PR DESCRIPTION
This adds a new pagination extension that does most of what the existing one does but is now able to work with any custom endpoint so long as it follows the same pagination options. With this I added support for transactions which are scoped under a user guid. If we merge this PR I'll follow up with support for paginating transactions under members and accounts as well.

The contract changes a tiny bit:
```ruby
# Return the first page like we're currently doing:
Transaction.list(:user_guid => "USR-123") #=> PaginationBatch

# Page through all transactions yielding each:
Transaction.list_each(:user_guid => "USR-123") { |transaction| puts transaction }

# List in batches:
Transaction.list_in_batches(:user_guid => "USR-123") { |batch| puts batch.size }

# Query params work with all of the above examples:
query_params => { :from_date => Date.new(2017, 2, 14) }
Transaction.list_each(:user_guid => "USR-123", :query_params => query_params) { |t| puts t }

# You can set the 'records_per_page' and 'limit' (also works with all of the above examples):
Transaction.list_each(:user_guid => "USR-123", :records_per_page => 1000) { |t| puts t }
Transaction.list_each(:user_guid => "USR-123", :limit => 100) { |t| puts t }

# And pagination batches include info similar to what you'd expect from WillPaginate
class PaginationBatch < ::Array
  attr_accessor :total_pages, :total_entries, :current_page, :records_per_page
end
```

cc @ztoolson  @jpotts18