### PR TITLE
Add optional proxy_url parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ end
 
 ```
 
+## Optional Proxy Parameter
+
+To use a proxy, set the optional `proxy_url` parameter to your proxy url when initializing the AtriumClient.
+```ruby
+client = Atrium::AtriumClient.new("YOUR_API_KEY", "YOUR_CLIENT_ID", :proxy_url => "YOUR_PROXY_URL")
+```
+
 ## Documentation for API Endpoints
 
 Class | Method | HTTP request | Description
@@ -161,4 +168,3 @@ Class | Method | HTTP request | Description
  - [Atrium::UserResponseBody](docs/UserResponseBody.md)
  - [Atrium::UserUpdateRequestBody](docs/UserUpdateRequestBody.md)
  - [Atrium::UsersResponseBody](docs/UsersResponseBody.md)
-

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Atrium - the Ruby gem for the MX API
 
-The MX Atrium API supports over 48,000 data connections to thousands of financial institutions. It provides secure access to your users' accounts and transactions with industry-leading cleansing, categorization, and classification.  Atrium is designed according to resource-oriented REST architecture and responds with JSON bodies and HTTP response codes.  Use Atrium's development environment, vestibule.mx.com, to quickly get up and running. The development environment limits are 100 users, 25 members per user, and access to the top 15 institutions. Contact MX to purchase production access.
+The MX Atrium API supports over 48,000 data connections to thousands of financial institutions. It provides secure access to your users' accounts and transactions with industry-leading cleansing, categorization, and classification.  Atrium is designed according to resource-oriented REST architecture and responds with JSON bodies and HTTP response codes.  Use Atrium's development environment, vestibule.mx.com, to quickly get up and running. The development environment limits are 100 users, 25 members per user, and access to the top 15 institutions. Contact MX to purchase production access. 
 
 ## Installation
 
@@ -17,12 +17,12 @@ gem build atrium-ruby.gemspec
 Then either install the gem locally:
 
 ```shell
-gem install ./atrium-ruby-2.1.1.gem
+gem install ./atrium-ruby-2.1.2.gem
 ```
 
 Finally add this to the Gemfile:
 
-    gem 'atrium-ruby', '~> 2.1.1'
+    gem 'atrium-ruby', '~> 2.1.2'
 
 ### Install from Git
 
@@ -49,7 +49,7 @@ client = Atrium::AtriumClient.new("YOUR_API_KEY", "YOUR_CLIENT_ID")
 
 account_guid = "ACT-123" # String | The unique identifier for an `account`.
 user_guid = "USR-123" # String | The unique identifier for a `user`.
-opts = {
+opts = { 
   from_date: "2016-09-20", # String | Filter transactions from this date.
   to_date: "2016-10-20" # String | Filter transactions to this date.
   page: 1, # Integer | Specify current page.
@@ -161,3 +161,4 @@ Class | Method | HTTP request | Description
  - [Atrium::UserResponseBody](docs/UserResponseBody.md)
  - [Atrium::UserUpdateRequestBody](docs/UserUpdateRequestBody.md)
  - [Atrium::UsersResponseBody](docs/UsersResponseBody.md)
+

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ gem build atrium-ruby.gemspec
 Then either install the gem locally:
 
 ```shell
-gem install ./atrium-ruby-2.1.2.gem
+gem install ./atrium-ruby-2.2.2.gem
 ```
 
 Finally add this to the Gemfile:
 
-    gem 'atrium-ruby', '~> 2.1.2'
+    gem 'atrium-ruby', '~> 2.2.2'
 
 ### Install from Git
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Atrium - the Ruby gem for the MX API
 
-The MX Atrium API supports over 48,000 data connections to thousands of financial institutions. It provides secure access to your users' accounts and transactions with industry-leading cleansing, categorization, and classification.  Atrium is designed according to resource-oriented REST architecture and responds with JSON bodies and HTTP response codes.  Use Atrium's development environment, vestibule.mx.com, to quickly get up and running. The development environment limits are 100 users, 25 members per user, and access to the top 15 institutions. Contact MX to purchase production access. 
+The MX Atrium API supports over 48,000 data connections to thousands of financial institutions. It provides secure access to your users' accounts and transactions with industry-leading cleansing, categorization, and classification.  Atrium is designed according to resource-oriented REST architecture and responds with JSON bodies and HTTP response codes.  Use Atrium's development environment, vestibule.mx.com, to quickly get up and running. The development environment limits are 100 users, 25 members per user, and access to the top 15 institutions. Contact MX to purchase production access.
 
 ## Installation
 
@@ -49,7 +49,7 @@ client = Atrium::AtriumClient.new("YOUR_API_KEY", "YOUR_CLIENT_ID")
 
 account_guid = "ACT-123" # String | The unique identifier for an `account`.
 user_guid = "USR-123" # String | The unique identifier for a `user`.
-opts = { 
+opts = {
   from_date: "2016-09-20", # String | Filter transactions from this date.
   to_date: "2016-10-20" # String | Filter transactions to this date.
   page: 1, # Integer | Specify current page.
@@ -64,13 +64,6 @@ rescue Atrium::ApiError => e
   puts "Exception when calling AccountsApi->list_account_transactions: #{e}"
 end
 
-```
-
-## Optional Proxy Parameter
-
-To use a proxy, set the optional `proxy_url` parameter to your proxy url when initializing the AtriumClient.
-```ruby
-client = Atrium::AtriumClient.new("YOUR_API_KEY", "YOUR_CLIENT_ID", :proxy_url => "YOUR_PROXY_URL")
 ```
 
 ## Documentation for API Endpoints

--- a/lib/atrium-ruby/api/atrium_client.rb
+++ b/lib/atrium-ruby/api/atrium_client.rb
@@ -11,12 +11,13 @@ module Atrium
     attr_accessor :users
     attr_accessor :verification
 
-    def initialize(api_key, client_id)
+    def initialize(api_key, client_id, opts = {})
       Atrium.configure do |config|
         config.api_key['MX-API-Key'] = api_key
         config.api_key['MX-Client-ID'] = client_id
+        config.proxy_url = opts[:proxy_url] if opts.has_key?(:proxy_url)
       end
-      
+
       @accounts = Atrium::AccountsApi.new()
       @connectWidget = Atrium::ConnectWidgetApi.new()
       @holdings = Atrium::HoldingsApi.new()

--- a/lib/atrium-ruby/api/atrium_client.rb
+++ b/lib/atrium-ruby/api/atrium_client.rb
@@ -11,11 +11,10 @@ module Atrium
     attr_accessor :users
     attr_accessor :verification
 
-    def initialize(api_key, client_id, opts = {})
+    def initialize(api_key, client_id)
       Atrium.configure do |config|
         config.api_key['MX-API-Key'] = api_key
         config.api_key['MX-Client-ID'] = client_id
-        config.proxy_url = opts[:proxy_url] if opts.has_key?(:proxy_url)
       end
 
       @accounts = Atrium::AccountsApi.new()

--- a/lib/atrium-ruby/api/atrium_client.rb
+++ b/lib/atrium-ruby/api/atrium_client.rb
@@ -16,7 +16,7 @@ module Atrium
         config.api_key['MX-API-Key'] = api_key
         config.api_key['MX-Client-ID'] = client_id
       end
-
+      
       @accounts = Atrium::AccountsApi.new()
       @connectWidget = Atrium::ConnectWidgetApi.new()
       @holdings = Atrium::HoldingsApi.new()

--- a/lib/atrium-ruby/api_client.rb
+++ b/lib/atrium-ruby/api_client.rb
@@ -105,7 +105,8 @@ module Atrium
         :ssl_verifyhost => _verify_ssl_host,
         :sslcert => @config.cert_file,
         :sslkey => @config.key_file,
-        :verbose => @config.debugging
+        :verbose => @config.debugging,
+        :proxy => @config.proxy_url
       }
 
       # set custom cert, if provided

--- a/lib/atrium-ruby/configuration.rb
+++ b/lib/atrium-ruby/configuration.rb
@@ -123,6 +123,8 @@ module Atrium
 
     attr_accessor :force_ending_format
 
+    attr_accessor :proxy_url
+
     def initialize
       @scheme = 'https'
       @host = 'vestibule.mx.com'
@@ -140,6 +142,7 @@ module Atrium
       @inject_format = false
       @force_ending_format = false
       @logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
+      @proxy_url = nil
 
       yield(self) if block_given?
     end

--- a/lib/atrium-ruby/version.rb
+++ b/lib/atrium-ruby/version.rb
@@ -7,5 +7,5 @@
 =end
 
 module Atrium
-  VERSION = '2.1.1'
+  VERSION = '2.1.2'
 end

--- a/lib/atrium-ruby/version.rb
+++ b/lib/atrium-ruby/version.rb
@@ -7,5 +7,5 @@
 =end
 
 module Atrium
-  VERSION = '2.1.2'
+  VERSION = '2.2.2'
 end


### PR DESCRIPTION
Adds an optional `proxy_url` parameter that can be set when initializing
the client to send requests via a proxy.

@liveh2o 

https://github.com/mxenabled/atrium-ruby/issues/60