### PR TITLE
Fix deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'rake', '~> 12.0.0'
+  gem 'rake', '>= 12.3.3'
 end

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ gem build atrium-ruby.gemspec
 Then either install the gem locally:
 
 ```shell
-gem install ./atrium-ruby-2.10.4.gem
+gem install ./atrium-ruby-2.10.5.gem
 ```
 
 Finally add this to the Gemfile:
 
-    gem 'atrium-ruby', '~> 2.10.4'
+    gem 'atrium-ruby', '~> 2.10.5'
 
 ### Install from Git
 

--- a/atrium-ruby.gemspec
+++ b/atrium-ruby.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = ">= 1.9"
 
+  s.add_runtime_dependency 'addressable', '~> 2.3', '>= 2.3.0'
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
 

--- a/lib/atrium-ruby/api_client.rb
+++ b/lib/atrium-ruby/api_client.rb
@@ -11,7 +11,7 @@ require 'json'
 require 'logger'
 require 'tempfile'
 require 'typhoeus'
-require 'uri'
+require 'addressable/uri'
 
 module Atrium
   class ApiClient
@@ -261,7 +261,7 @@ module Atrium
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      Addressable::URI.encode(@config.base_url + path)
     end
 
     # Builds the HTTP request body

--- a/lib/atrium-ruby/configuration.rb
+++ b/lib/atrium-ruby/configuration.rb
@@ -6,7 +6,7 @@
 
 =end
 
-require 'uri'
+require 'addressable/uri'
 
 module Atrium
   class Configuration
@@ -174,7 +174,7 @@ module Atrium
 
     def base_url
       url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      Addressable::URI.encode(url)
     end
 
     # Gets API key (with prefix if set).

--- a/lib/atrium-ruby/version.rb
+++ b/lib/atrium-ruby/version.rb
@@ -7,5 +7,5 @@
 =end
 
 module Atrium
-  VERSION = '2.10.4'
+  VERSION = '2.10.5'
 end


### PR DESCRIPTION
Fixes `warning: URI.escape is obsolete` deprecation warning. Also
updates `rake` gem per Dependabot alert.